### PR TITLE
Missing MediaMTX will not throw error

### DIFF
--- a/opentakserver/app.py
+++ b/opentakserver/app.py
@@ -163,14 +163,17 @@ def create_app():
             config.write(yaml.safe_dump(conf))
 
         # Try to set the MediaMTX token
-        try:
-            with open(os.path.join(app.config.get("OTS_DATA_FOLDER"), "mediamtx", "mediamtx.yml"), "r") as mediamtx_config:
-                conf = mediamtx_config.read()
-                conf = conf.replace("MTX_TOKEN", app.config.get("OTS_MEDIAMTX_TOKEN"))
-            with open(os.path.join(app.config.get("OTS_DATA_FOLDER"), "mediamtx", "mediamtx.yml"), "w") as mediamtx_config:
-                mediamtx_config.write(conf)
-        except BaseException as e:
-            logger.error("Failed to set MediaMTX token: {}".format(e))
+        if app.config.get("OTS_MEDIAMTX_ENABLE"):
+            try:
+                with open(os.path.join(app.config.get("OTS_DATA_FOLDER"), "mediamtx", "mediamtx.yml"), "r") as mediamtx_config:
+                    conf = mediamtx_config.read()
+                    conf = conf.replace("MTX_TOKEN", app.config.get("OTS_MEDIAMTX_TOKEN"))
+                with open(os.path.join(app.config.get("OTS_DATA_FOLDER"), "mediamtx", "mediamtx.yml"), "w") as mediamtx_config:
+                    mediamtx_config.write(conf)
+            except BaseException as e:
+                logger.error("Failed to set MediaMTX token: {}".format(e))
+        else:
+            logger.info("MediaMTX disabled")
 
     init_extensions(app)
 

--- a/opentakserver/defaultconfig.py
+++ b/opentakserver/defaultconfig.py
@@ -24,6 +24,7 @@ class DefaultConfig:
     OTS_SSL_STREAMING_PORT = 8089
     OTS_BACKUP_COUNT = 7
     OTS_RABBITMQ_SERVER_ADDRESS = "127.0.0.1"
+    OTS_MEDIAMTX_ENABLE = True
     OTS_MEDIAMTX_API_ADDRESS = "http://localhost:9997"
     OTS_MEDIAMTX_TOKEN = str(secrets.SystemRandom().getrandbits(128))
     OTS_SSL_VERIFICATION_MODE = 2  # Equivalent to ssl.CERT_REQUIRED. https://docs.python.org/3/library/ssl.html#ssl.SSLContext.verify_mode


### PR DESCRIPTION
Hope this is okay, was tired of seeing the error message.

`[2024-04-24 12:31:03,773] - OpenTAKServer[1] - app - ERROR - Failed to set MediaMTX token: [Errno 2] No such file or directory: '/app/ots/mediamtx/mediamtx.yml'`