### PR TITLE
Health Check Url

### DIFF
--- a/opentakserver/blueprints/api.py
+++ b/opentakserver/blueprints/api.py
@@ -91,6 +91,13 @@ def change_config_setting(setting, value):
     except BaseException as e:
         logger.error("Failed to change setting {} to {} in config.yml: {}".format(setting, value, e))
 
+@api_blueprint.route('/api/health')
+def health():
+    if app.cot_thread.iothread.is_alive():
+        return jsonify({'status': 'down', 'error': 'cot thread is dead'}), 503
+
+    return jsonify({'status': 'healthy'})
+
 
 @api_blueprint.route('/api/status')
 @auth_required()


### PR DESCRIPTION
Hi

I'm not the biggest python person.
But i tried to add an url that have no auth
so I can add healthcheck to the Docker setup I'm working on.

This also helps me "boot" the containers in the correct order.

```shell
docker ps --format "table {{.Names}}\t{{.Status}}"
NAMES           STATUS
opentakserver   Up 15 minutes
rabbitmq        Up 15 minutes (healthy)
nginx           Up 15 minutes (healthy)
```

As you see opentakserver is missing !


--- 

### Added one to nginx also

```nginx
server {

    listen 80;
    server_name _;

    location = /health {
        access_log off;
        add_header 'Content-Type' 'application/json';
        return 200 '{"status":"healthy"}';
    }

}
```

```shell
curl -k https://localhost/health
{"status":"healthy"}
```