### PR TITLE
Update MissionChange.py to resolve crashes.

### DIFF
--- a/opentakserver/models/MissionChange.py
+++ b/opentakserver/models/MissionChange.py
@@ -55,7 +55,7 @@ class MissionChange(db.Model):
         json = {
             "isFederatedChange": self.isFederatedChange,
             "type": self.change_type,
-            "contentUid": self.content_uid,
+            "contentUid": self.content_uid if self.content_uid != None else self.mission_uid if self.mission_uid != None else self.mission.guid,
             "missionName": self.mission_name,
             "timestamp": iso8601_string_from_datetime(self.timestamp),
             "creatorUid": self.creator_uid if self.creator_uid else "",
@@ -91,7 +91,7 @@ def generate_mission_change_cot(author_uid: str, mission: Mission, mission_chang
     detail = SubElement(event, "detail")
     mission_element = SubElement(detail, "mission",
                                  {"type": MissionChange.CHANGE, "tool": "public", "name": mission.name,
-                                  "guid": mission.guid, "authorUid": author_uid})
+                                  "guid": mission.guid, "authorUid": mission.creator_uid})
     mission_changes_element = SubElement(mission_element, "MissionChanges")
     mission_change_element = SubElement(mission_changes_element, "MissionChange")
 


### PR DESCRIPTION
This will create a fallback situation on content_uid where it will allow for:

1. actual content items to have the right mission_content UID
2. markers will have their content_uid from the COT emitted from the endpoint, 
3. and the Mission CREATE database entry will use the Mission GUID as the content_uid 

It appears from testing that content_uid must never be blank.   

Its possible the use of mission.guid as the mission CREATE line item content_uid is a misnomer, but it seems to work in all cases as of testing right now.  

This change also ensures that the mission author is populated.  