### PR TITLE
Fixes from TAK Aware testing

### DIFF
--- a/opentakserver/blueprints/marti_api/certificate_enrollment_api.py
+++ b/opentakserver/blueprints/marti_api/certificate_enrollment_api.py
@@ -81,7 +81,12 @@ def sign_csr_v2():
 
         csr = request.data.decode('utf-8')
         if "BEGIN CERTIFICATE REQUEST" not in csr:
-            csr = '-----BEGIN CERTIFICATE REQUEST-----\n' + csr + '-----END CERTIFICATE REQUEST-----'
+            csr = '-----BEGIN CERTIFICATE REQUEST-----\n' + csr
+
+        if not csr.endswith('\n'):
+            csr = csr + '\n'
+            
+        csr = csr + '-----END CERTIFICATE REQUEST-----'
 
         x509 = crypto.load_certificate_request(crypto.FILETYPE_PEM, csr.encode())
 

--- a/opentakserver/blueprints/marti_api/mission_marti_api.py
+++ b/opentakserver/blueprints/marti_api/mission_marti_api.py
@@ -13,7 +13,7 @@ import jwt
 import bleach
 import sqlalchemy.exc
 from bs4 import BeautifulSoup
-from flask import Blueprint, request, current_app as app, jsonify
+from flask import Blueprint, request, current_app as app, jsonify, Response
 from flask_security import current_user, hash_password, verify_password
 from sqlalchemy import update, insert
 from werkzeug.utils import secure_filename
@@ -1362,7 +1362,7 @@ def get_mission_cots(mission_name: str = None, mission_guid: str = None):
     for cot in cots:
         events.append(fromstring(cot[0].xml))
 
-    return tostring(events).decode('utf-8'), 200
+    return Response(response=tostring(events).decode('utf-8'), status=200, mimetype='application/xml')
 
 
 @mission_marti_api.route('/Marti/api/missions/<mission_name>/layers')


### PR DESCRIPTION
Contributing two fixes from some testing with TAK Aware:

- During certificate enrollment the code wraps the CSR with a header + line break but assumes that the body has a line break already before suffixing the footer. This checks for and adds a line break if needed
- In the mission API for /cot it was returning `text/html` instead of `application/xml` which was being rejected by TAK Aware for being an improper mime type response. This adds in `Response` from flask and uses it to specify the mimeType of the response for that API