### PR TITLE
Fix: PostgreSQL operator mismatch in marti_api/cot_marti_api.py

### DIFF
--- a/opentakserver/blueprints/marti_api/cot_marti_api.py
+++ b/opentakserver/blueprints/marti_api/cot_marti_api.py
@@ -48,7 +48,7 @@ def get_all_cot(uid):
     query = db.session.query(CoT).filter_by(uid=uid)
     if sec_ago:
         try:
-            query = query.filter(CoT.start >= datetime.timedelta(seconds=int(sec_ago)))
+            query = query.filter(CoT.start >= datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=int(sec_ago)))
         except ValueError:
             return (
                 jsonify(


### PR DESCRIPTION
## Problem
When running OpenTAKServer on with PostgreSQL, the `/Marti/api/cot/xml/...` endpoint fails with a `psycopg.errors.UndefinedFunction: operator does not exist: timestamp without time zone >= interval`.

This happens because SQLAlchemy/Postgres cannot compare a `CoT.start` (timestamp) directly against a `timedelta` (interval).

## Solution
Modified the filter to compare the `CoT.start` timestamp against a calculated `datetime` object (Current Time - Delta) instead of passing the delta directly to the query.

## Testing
- Environment: Ubuntu 24.04, Python 3.12, PostgreSQL 16.
- Verified that the GET request now returns valid XML CoT data instead of a 500 Internal Server Error.