### PR TITLE
TLS handshake timeout

### DIFF
--- a/opentakserver/eud_handler/SocketServer.py
+++ b/opentakserver/eud_handler/SocketServer.py
@@ -32,7 +32,17 @@ class SocketServer:
         while not self.shutdown:
             try:
                 sock, addr = self.socket.accept()
+
                 if self.ssl:
+                    try:
+                        sock.settimeout(10)
+                        sock.do_handshake()
+                        sock.settimeout(None)
+                    except (socket.timeout, ssl.SSLError, OSError) as e:
+                        self.logger.warning("TLS handshake failed from {}: {}".format(addr[0], e))
+                        sock.close()
+                        continue
+
                     self.logger.info("New SSL connection from {}".format(addr[0]))
                 else:
                     self.logger.info("New TCP connection from {}".format(addr[0]))
@@ -82,7 +92,7 @@ class SocketServer:
 
             context = self.get_ssl_context()
 
-            sconn = context.wrap_socket(sock, server_side=True)
+            sconn = context.wrap_socket(sock, server_side=True, do_handshake_on_connect=False)
             sconn.bind(("0.0.0.0", self.port))
             sconn.listen(0)
 


### PR DESCRIPTION
Set a timeout on the TLS handshake to prevent misbehaving or gone clients from locking up eud_handler indefinitely. 

As mentioned on Discord #support. 

## Reproduction of original bug
Tested on 1.7.10

1. restart the eud_handler service to get it up and running again
2. connect ATAK client (which should work)
3. disconnect ATAK client
4. Run `nc localhost 8089` on the server to lock up the socket by never completing the TLS handshake
5. Reconnect ATAK (which should fail)
6. stop connecting ATAK client
7. Stop nc command
8. connect ATAK client (which should work)

## Testing of the fix
I've manually tested this change on my server, and it does work as intended: `nc` is kicked off the socket after 10 seconds, freeing up the socket for use by ATAK. 
