### PR TITLE
Fix FileNotFoundError when downloading plugins from TAK.gov

### DIFF
--- a/opentakserver/blueprints/ots_api/tak_gov_link_api.py
+++ b/opentakserver/blueprints/ots_api/tak_gov_link_api.py
@@ -301,6 +301,7 @@ def download_plugin():
 
     content_disposition = response.headers.get("content-disposition")
     filename = re.search(r"filename=\"(.+)\"", content_disposition).group(1)
+    os.makedirs(os.path.join(app.config.get("OTS_DATA_FOLDER"), "packages"), exist_ok=True)
     with open(os.path.join(app.config.get("OTS_DATA_FOLDER"), "packages", filename), "wb") as f:
         f.write(response.content)
 


### PR DESCRIPTION
## Summary

- `download_plugin()` in `tak_gov_link_api.py` writes to the `packages` subdirectory without ensuring it exists first
- If no plugin has previously been uploaded through the normal package API (which creates the directory), the download fails with `FileNotFoundError`
- Added `os.makedirs(..., exist_ok=True)` before the file write, matching the pattern already used in `package_api.py`

## Steps to reproduce

1. Fresh OTS install (no plugins uploaded yet via package API)
2. Link a TAK.gov account
3. Attempt to download any plugin
4. Fails with: `FileNotFoundError: [Errno 2] No such file or directory: '.../packages/<filename>.apk'`

## Test plan

- [ ] Verify plugin download works on a fresh install with no pre-existing `packages` directory
- [ ] Verify plugin download still works when `packages` directory already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)