### PR TITLE
Fix device profile filtering for null eud_uid

### DIFF
--- a/opentakserver/blueprints/marti_api/device_profile_marti_api.py
+++ b/opentakserver/blueprints/marti_api/device_profile_marti_api.py
@@ -182,11 +182,11 @@ def create_profile_zip(enrollment=True, syncSecago=-1, clientUid: str | None = N
             plugins_query = plugins_query.filter(Packages.publish_time >= publish_time)
         if clientUid:
             device_profile_query = device_profile_query.filter(
-                or_(DeviceProfiles.eud_uid == clientUid, DeviceProfiles.eud_uid is None)
+                or_(DeviceProfiles.eud_uid == clientUid, DeviceProfiles.eud_uid.is_(None))
             )
             # TODO: Support data packages and plugins per EUD
         else:
-            device_profile_query = device_profile_query.filter(DeviceProfiles.clientUid is None)
+            device_profile_query = device_profile_query.filter(DeviceProfiles.eud_uid.is_(None))
 
         device_profiles = db.session.execute(device_profile_query).all()
         data_packages = db.session.execute(data_package_query).all()


### PR DESCRIPTION
## Summary

- `DeviceProfiles.eud_uid is None` uses Python identity check instead of SQLAlchemy's `.is_(None)`, so the SQL filter never matches profiles without an EUD assignment. Global device profiles were never delivered to devices on connection.
- `DeviceProfiles.clientUid` on line 189 references a non-existent column (should be `eud_uid`), which would raise `AttributeError` when a device requests a connection profile without a `clientUid` parameter.

## Test plan

- [ ] Create a device profile without assigning a callsign/EUD — verify it appears in the list
- [ ] Connect an EUD with `repoStartupSync` enabled and no `clientUid` param — verify global profiles are delivered
- [ ] Connect an EUD with a `clientUid` param — verify it receives both its own profiles and global (unassigned) profiles

Fixes #253 (backend half — companion UI PR at brian7704/OpenTAKServer-UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)