### PR TITLE
Add configurable map defaults via admin settings API

### DIFF
--- a/opentakserver/blueprints/ots_api/__init__.py
+++ b/opentakserver/blueprints/ots_api/__init__.py
@@ -22,6 +22,7 @@ from opentakserver.blueprints.ots_api.video_api import video_api_blueprint
 from .language_api import language_api
 from .ldap_api import ldap_blueprint
 from .tak_gov_link_api import tak_gov_link_blueprint
+from .config_api import config_api_blueprint
 
 ots_api = Blueprint("ots_api", __name__)
 ots_api.register_blueprint(api_blueprint)
@@ -43,3 +44,4 @@ ots_api.register_blueprint(token_api_blueprint)
 ots_api.register_blueprint(ldap_blueprint)
 ots_api.register_blueprint(tak_gov_link_blueprint)
 ots_api.register_blueprint(language_api)
+ots_api.register_blueprint(config_api_blueprint)

--- a/opentakserver/blueprints/ots_api/config_api.py
+++ b/opentakserver/blueprints/ots_api/config_api.py
@@ -1,0 +1,44 @@
+from flask import Blueprint, jsonify, request
+from flask import current_app as app
+from flask_babel import gettext
+from flask_security import auth_required, roles_required
+
+from opentakserver.blueprints.ots_api.api import change_config_setting
+from opentakserver.extensions import logger
+
+config_api_blueprint = Blueprint("config_api_blueprint", __name__)
+
+CONFIG_WHITELIST = {
+    "OTS_MAP_DEFAULT_LAT",
+    "OTS_MAP_DEFAULT_LON",
+    "OTS_MAP_DEFAULT_ZOOM",
+    "OTS_MAP_DEFAULT_LAYER",
+}
+
+
+@config_api_blueprint.route("/api/config")
+@auth_required()
+def get_config():
+    return jsonify({key: app.config.get(key) for key in CONFIG_WHITELIST})
+
+
+@config_api_blueprint.route("/api/config", methods=["PUT"])
+@auth_required()
+@roles_required("administrator")
+def update_config():
+    data = request.json
+    if not data:
+        return jsonify({"success": False, "error": gettext("No data provided")}), 400
+
+    invalid_keys = set(data.keys()) - CONFIG_WHITELIST
+    if invalid_keys:
+        return jsonify({
+            "success": False,
+            "error": gettext("Invalid config keys: %(keys)s", keys=", ".join(invalid_keys))
+        }), 400
+
+    for key, value in data.items():
+        change_config_setting(key, value)
+        app.config[key] = value
+
+    return jsonify({"success": True})

--- a/opentakserver/defaultconfig.py
+++ b/opentakserver/defaultconfig.py
@@ -45,6 +45,12 @@ class DefaultConfig:
     OTS_BACKUP_COUNT = int(os.getenv("OTS_BACKUP_COUNT", 7))
     OTS_ENABLE_CHANNELS = os.getenv("OTS_ENABLE_CHANNELS", "True").lower() in ["true", "1", "yes"]
 
+    # Map defaults
+    OTS_MAP_DEFAULT_LAT = float(os.getenv("OTS_MAP_DEFAULT_LAT", 10))
+    OTS_MAP_DEFAULT_LON = float(os.getenv("OTS_MAP_DEFAULT_LON", 0))
+    OTS_MAP_DEFAULT_ZOOM = int(os.getenv("OTS_MAP_DEFAULT_ZOOM", 3))
+    OTS_MAP_DEFAULT_LAYER = os.getenv("OTS_MAP_DEFAULT_LAYER", "OSM")
+
     # RabbitMQ Settings
     OTS_RABBITMQ_SERVER_ADDRESS = os.getenv("OTS_RABBITMQ_SERVER_ADDRESS", "127.0.0.1")
     OTS_RABBITMQ_USERNAME = os.getenv("OTS_RABBITMQ_USERNAME", "guest")


### PR DESCRIPTION
## Summary

- Add `OTS_MAP_DEFAULT_LAT`, `OTS_MAP_DEFAULT_LON`, `OTS_MAP_DEFAULT_ZOOM`, `OTS_MAP_DEFAULT_LAYER` config settings to `defaultconfig.py`
- New `GET/PUT /api/config` endpoint with a whitelist that only exposes safe config keys (map settings initially, expandable for future settings)
- `GET` is available to any authenticated user (needed for map rendering), `PUT` is admin-only
- Defaults match current hardcoded behavior (lat 10, lon 0, zoom 3, OSM) so existing installs see no change

## Test plan

- [ ] `GET /api/config` returns the four map settings for an authenticated user
- [ ] `PUT /api/config` with valid keys updates `config.yml` and in-memory config
- [ ] `PUT /api/config` with non-whitelisted keys returns 400
- [ ] Non-admin users get 403 on PUT
- [ ] Existing installs without the new keys in `config.yml` get defaults from `defaultconfig.py`

Companion UI PR: brian7704/OpenTAKServer-UI
Fixes brian7704/OpenTAKServer-UI#165

🤖 Generated with [Claude Code](https://claude.com/claude-code)