### PR TITLE
Enable sorting on Users and Groups API endpoints

### DIFF
--- a/opentakserver/blueprints/ots_api/group_api.py
+++ b/opentakserver/blueprints/ots_api/group_api.py
@@ -52,7 +52,7 @@ def get_groups():
     query = search(query, Group, "bitpos")
     query = search(query, Group, "active")
 
-    return paginate(query)
+    return paginate(query, Group)
 
 
 @group_api.route("/api/groups/all", methods=["GET"])

--- a/opentakserver/blueprints/ots_api/user_api.py
+++ b/opentakserver/blueprints/ots_api/user_api.py
@@ -454,7 +454,7 @@ def get_users():
     query = db.session.query(User)
     query = search(query, User, "username")
 
-    return paginate(query)
+    return paginate(query, User)
 
 
 @user_api_blueprint.route("/api/users/all")


### PR DESCRIPTION
## Summary

- Pass the model to `paginate()` in the Users and Groups API endpoints so `sort_by` and `sort_direction` query params are handled
- Without the model, `paginate()` skips the sorting logic entirely — this was already working for EUDs, Data Packages, etc. but was missing from Users and Groups

## Test plan

- [ ] `GET /api/users?sort_by=username&sort_direction=asc` returns users sorted by username
- [ ] `GET /api/groups?sort_by=name&sort_direction=desc` returns groups sorted by name descending
- [ ] `per_page` parameter still works on both endpoints
- [ ] Existing behavior unchanged when no sort params are provided

Companion UI PR: brian7704/OpenTAKServer-UI
Addresses brian7704/OpenTAKServer#282

🤖 Generated with [Claude Code](https://claude.com/claude-code)