### PR TITLE
Default to 'user' role when creating users with empty roles list

### DIFF
--- a/opentakserver/blueprints/ots_api/user_api.py
+++ b/opentakserver/blueprints/ots_api/user_api.py
@@ -53,6 +53,8 @@ def create_user():
         return jsonify({"success": False, "error": gettext("Passwords do not match")}), 400
 
     roles = request.json.get("roles")
+    if not roles:
+        roles = ["user"]
     roles_cleaned = []
 
     for role in roles:


### PR DESCRIPTION
## Summary

When creating a user via `POST /api/user/add` with an empty `roles` list (or `roles` omitted), the user is created with no role assigned. This breaks the web UI — the Users page crashes because it accesses `roles[0].name` on a user with no roles, and no users are displayed at all.

This PR defaults to the `"user"` role when `roles` is empty or not provided.

## Note on the UI crash

This PR fixes the root cause (backend allows invalid state). The UI crash itself is also independently fixed by brian7704/OpenTAKServer-UI#178, which converts the Users page to DataTable and uses optional chaining (`roles[0]?.name`). **Either PR alone fixes the user-visible bug** — this one prevents the bad data from being created, the UI PR handles it gracefully if it exists. Both are good to have for defense in depth, but they don't depend on each other.

## Test plan

- [ ] `POST /api/user/add` with `"roles": []` creates user with `"user"` role
- [ ] `POST /api/user/add` with `"roles"` omitted creates user with `"user"` role
- [ ] `POST /api/user/add` with `"roles": ["administrator"]` still works as before
- [ ] Users page renders correctly after creating a user via API with empty roles

Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)