### PR TITLE
Apply sort_by/sort_direction on /api/cot, /api/point, /api/icon

### DIFF
--- a/opentakserver/blueprints/ots_api/api.py
+++ b/opentakserver/blueprints/ots_api/api.py
@@ -393,7 +393,7 @@ def query_cot():
     query = search(query, CoT, "sender_callsign")
     query = search(query, CoT, "sender_uid")
 
-    return paginate(query)
+    return paginate(query, CoT)
 
 
 @api_blueprint.route("/api/alerts", methods=["GET"])
@@ -430,7 +430,7 @@ def query_points():
     query = search(query, EUD, "uid")
     query = search(query, EUD, "callsign")
 
-    return paginate(query)
+    return paginate(query, Point)
 
 
 @api_blueprint.route("/api/rabbitmq/<path>", methods=["POST"])
@@ -582,7 +582,7 @@ def get_icon():
     query = search(query, Icon, "groupName")
     query = search(query, Icon, "type2525b")
 
-    return paginate(query)
+    return paginate(query, Icon)
 
 
 @api_blueprint.route("/api/itak_qr_string")


### PR DESCRIPTION
paginate() only applies the sort_by/sort_direction query args when called with a model argument (gated at the `if model:` check). These three routes were calling paginate(query) without the model, so the sort params were silently dropped and rows came back in undefined (typically PK-ascending) order. Pass the corresponding model so client queries like ?sort_by=timestamp&sort_direction=desc actually take effect.