### PR TITLE
fix(marti): return per-peer username on /Marti/api/clientEndPoints

### DIFF
--- a/opentakserver/blueprints/marti_api/marti_api.py
+++ b/opentakserver/blueprints/marti_api/marti_api.py
@@ -7,7 +7,6 @@ from flask import Blueprint
 from flask import current_app as app
 from flask import jsonify, request, send_from_directory
 from flask_babel import gettext
-from flask_security import current_user
 from OpenSSL import crypto
 from OpenSSL.crypto import X509
 from simplekml import Document, GxMultiTrack, GxTrack, Icon, IconStyle, Kml, Style
@@ -62,7 +61,7 @@ def client_end_points():
             {
                 "callsign": eud.callsign,
                 "uid": eud.uid,
-                "username": current_user.username if current_user.is_authenticated else "anonymous",
+                "username": eud.user.username if eud.user else "anonymous",
                 "lastEventTime": iso8601_string_from_datetime(eud.last_event_time),
                 "lastStatus": eud.last_status,
             }


### PR DESCRIPTION
## Summary

`client_end_points()` set the `username` field on every entry in the response to `current_user.username` (the requesting user). Each entry's `username` should be the username of the user that owns *that* EUD.

## Repro

1. Create two users (`alice`, `bob`) and have each connect at least one EUD with a callsign.
2. Authenticate as `alice` and `GET /Marti/api/clientEndPoints`.
3. Every entry comes back with `"username": "alice"`, including the entry for `bob`'s EUD.

After this change every entry's `username` reflects the EUD's owning user, with `"anonymous"` as the fallback when `eud.user` is unset (preserving the prior fallback behavior).

This aligns with TAK Server's `ClientEndpoint` schema, where `username` describes the connected client, not the API caller.

## Test plan
- [ ] `GET /Marti/api/clientEndPoints` as user A; verify each peer's `username` matches its owning user, not user A
- [ ] EUDs without an associated user still return `"username": "anonymous"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)