### PR TITLE
ci: weekly scheduled rebuild of master container images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  schedule:
+    # Weekly Sunday 04:00 UTC — rebuild :master with fresh base image to pick up
+    # security fixes in python:3.13 / debian-bookworm without waiting for a new release.
+    - cron: '0 4 * * 0'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
### Motivation

The four images published by `.github/workflows/docker.yml` (`opentakserver`, `ots_cot_parser`, `ots_eud_handler`, `ots_eud_handler_ssl`) currently rebuild only when a new release is published. The `:master` tags then drift behind upstream Python and Debian security fixes between releases.

A trivy scan of the four `:master` images on `2026-05-02` (last published `2025-10-17`) found:

| Image | HIGH | CRITICAL |
|---|---|---|
| `ghcr.io/brian7704/ots_eud_handler:master` | 754 | 154 |
| `ghcr.io/brian7704/ots_eud_handler_ssl:master` | 754 | 154 |
| `ghcr.io/brian7704/ots_cot_parser:master` | 0 | 0 (clean) |
| `ghcr.io/brian7704/opentakserver:master` | 0 | 0 (clean) |

All `eud_handler` findings are in OS packages of the `python:3.13` base. Rebuilding the same Dockerfile with `--pull` against a current `python:3.13` reduces these to zero — no source changes, no application risk.

### Change

Adds a `schedule:` trigger to the existing `Docker Image CI` workflow:

```yaml
on:
  release:
    types: [published]
  workflow_dispatch:
  schedule:
    - cron: '0 4 * * 0'   # Sunday 04:00 UTC
```

The matrix already builds all four images with `--pull` semantics via `docker/build-push-action@v6`, so no other changes are needed. Weekly cadence matches typical Debian/Python base-image refresh cycles without burning excessive CI minutes.

### Alternatives considered

- **More frequent (daily):** Wasteful given base images don't refresh that often.
- **Less frequent (monthly):** Leaves a >30-day window for known-fixed CVEs.
- **Separate workflow:** Cleaner but adds a duplicate matrix definition. Inline `schedule:` reuses what's already there.

### Verified locally

Same Dockerfiles built with `docker build --pull` against current `python:3.13`:
- `ots_eud_handler` → 0 HIGH/CRITICAL OS CVEs
- `ots_eud_handler_ssl` → 0 HIGH/CRITICAL OS CVEs

Happy to adjust the cron schedule or split into a separate workflow file if preferred.