### PR TITLE
fix(api): case-insensitive sort on string columns in paginate helper

### DIFF
--- a/opentakserver/blueprints/ots_api/api.py
+++ b/opentakserver/blueprints/ots_api/api.py
@@ -18,7 +18,7 @@ from flask import jsonify, request, send_from_directory, session
 from flask_babel import gettext
 from flask_ldap3_login import AuthenticationResponseStatus
 from flask_security import auth_required, current_user, verify_password
-from sqlalchemy import select
+from sqlalchemy import String, Text, Unicode, UnicodeText, func, select
 
 from opentakserver import __version__ as version
 from opentakserver.certificate_authority import CertificateAuthority
@@ -68,10 +68,22 @@ def paginate(query: db.Query, model=None):
         if model:
             sort_by = request.args.get("sort_by")
             sort_direction = request.args.get("sort_direction")
-            if sort_by and (sort_direction == "asc" or not sort_direction):
-                query = query.order_by(getattr(model, sort_by).asc())
-            elif sort_by and sort_direction == "desc":
-                query = query.order_by(getattr(model, sort_by).desc())
+            if sort_by:
+                column = getattr(model, sort_by)
+                # Sort string columns case-insensitively so "alice" sorts next
+                # to "Alice" instead of after every uppercase entry (Postgres
+                # default collation is byte-ordered: Z < a).
+                try:
+                    is_string_col = isinstance(
+                        column.type, (String, Text, Unicode, UnicodeText)
+                    )
+                except AttributeError:
+                    is_string_col = False
+                sort_expr = func.lower(column) if is_string_col else column
+                if sort_direction == "desc":
+                    query = query.order_by(sort_expr.desc())
+                else:
+                    query = query.order_by(sort_expr.asc())
     except BaseException as e:
         return (
             jsonify(


### PR DESCRIPTION
## Summary

The `paginate()` helper in `opentakserver/blueprints/ots_api/api.py` centralizes server-side sorting for every paginated list endpoint (Users, Groups, EUDs, Missions, Tokens, Markers, etc.). It currently emits `ORDER BY <column>` directly, which uses Postgres' default byte-ordered collation — so on a username sort the rows come back as `ALICE, BOB, Charlie, alice, bob` rather than the natural mixed-case order admins expect.

This is most painful on the Users page when an admin is trying to find someone whose name capitalization they don't remember.

## Change

For string-typed columns (`String`, `Text`, `Unicode`, `UnicodeText`), wrap the sort expression with `func.lower(column)` so `alice, Bob, charlie, DAVID` sort in natural mixed-case order. Non-string columns (timestamps, IDs, counts, booleans, etc.) keep their existing behavior.

```python
column = getattr(model, sort_by)
is_string_col = isinstance(column.type, (String, Text, Unicode, UnicodeText))
sort_expr = func.lower(column) if is_string_col else column
```

Because the change lives in the central helper, it covers **every paginated endpoint** in one place — no per-blueprint follow-up needed.

## Test plan

- [x] Verified on a live OTS 1.7.11 / Postgres install with mixed-case usernames:
  - Before: `BernieParker, Bstarace, Dannydodson1976, DCR21, …, administrator, ae5iv, dhirenparbhoo`
  - After: `administrator, ae5iv, BernieParker, Bstarace, Dannydodson1976, DCR21, Devina.parbhoo, dhirenparbhoo, dibanchs, …`
- [ ] No regression on non-string sort columns (sort by `last_login_at`, `login_count`, etc. behaves the same).

## Notes

- ASCII lowering via `func.lower()` is sufficient for the current user base. Locale-aware Unicode collation (Postgres `ICU` collations) would be the next step if/when non-Latin usernames become a thing — out of scope here.
- The pre-fix raw sort happens to put every uppercase entry before every lowercase entry; the post-fix sort is what most users intuitively expect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)