### PR TITLE
fix(mission-api): correct typo in mission contents DELETE route

### DIFF
--- a/opentakserver/blueprints/marti_api/mission_marti_api.py
+++ b/opentakserver/blueprints/marti_api/mission_marti_api.py
@@ -2041,7 +2041,7 @@ def mission_contents(mission_name: str | None = None, mission_guid: str | None =
     )
 
 
-@mission_marti_api.route("/Marti/api/missions/gui/<mission_guid>/contents", methods=["DELETE"])
+@mission_marti_api.route("/Marti/api/missions/guid/<mission_guid>/contents", methods=["DELETE"])
 @mission_marti_api.route("/Marti/api/missions/<mission_name>/contents", methods=["DELETE"])
 def delete_content(mission_name: str | None = None, mission_guid: str | None = None):
     if "iTAK" not in request.user_agent.string:


### PR DESCRIPTION
## Summary

The mission contents DELETE route was registered as `/Marti/api/missions/**gui**/<mission_guid>/contents` (missing the `d` in `guid`). Any DELETE issued against the guid-form URL returns 405 Method Not Allowed.

```python
# opentakserver/blueprints/marti_api/mission_marti_api.py:2044  (before)
@mission_marti_api.route("/Marti/api/missions/gui/<mission_guid>/contents", methods=["DELETE"])
@mission_marti_api.route("/Marti/api/missions/<mission_name>/contents", methods=["DELETE"])
def delete_content(mission_name: str | None = None, mission_guid: str | None = None):
```

The companion PUT route for the same handler one screen above (line 1842) uses the correct `/guid/`, and the handler signature accepts `mission_guid`, confirming the typo was unintentional.

A repo-wide sweep for `/gui/` in `opentakserver/*.py` returns only this single line. All seven other `/missions/guid/<mission_guid>/…` routes in `mission_marti_api.py` are spelled correctly.

## Impact

Clients following the TAK Server Marti spec emit the guid form for content removal. In CloudTAK that path is `Mission.detachContents()` in `node-tak`, which builds:

```
DELETE /Marti/api/missions/guid/<guid>/contents?uid=<cot-uid>
```

Pre-patch, every such call silently 405s, leaving stale CoTs in the mission. Confirmed reproducible against `1.7.11` and present in `origin/master @ d539b73`.

## Test plan

- [x] Verified bug reproduces against `1.7.11` and against `origin/master` head
- [x] Verified the route fix on a live install (CloudTAK → `DELETE …/cot/<uid>` proxied through node-tak now returns 200, CoT is removed from mission)
- [x] `grep -rE '/gui/' opentakserver/` returns empty post-patch
- [ ] Add/extend integration test for DELETE `…/missions/guid/<guid>/contents?uid=<uid>` (happy to follow up in a separate PR if maintainer prefers test coverage as a precondition)

## Backports

Affects all current and recent OTS releases (`1.7.11` confirmed). One-line patch should cherry-pick cleanly to any maintained branch.