### PR TITLE
fix: use queue_unbind instead of queue_bind in send_disconnect_cot

### DIFF
--- a/opentakserver/cot_parser/cot_parser.py
+++ b/opentakserver/cot_parser/cot_parser.py
@@ -986,7 +986,7 @@ class CoTController:
                             ),
                         )
 
-                        self.rabbit_channel.queue_bind(
+                        self.rabbit_channel.queue_unbind(
                             queue=uid,
                             exchange="groups",
                             routing_key=f"{group.group.name}.{group.direction}",


### PR DESCRIPTION
send_disconnect_cot calls queue_bind but should be queue_unbind. The debug log on line 996 says "Unbound" and the other two disconnect paths call queue_unbind