### PR TITLE
Fix Mumble auth lookup for ATAK Vx plugin usernames

### DIFF
--- a/opentakserver/mumble/mumble_authenticator.py
+++ b/opentakserver/mumble/mumble_authenticator.py
@@ -34,6 +34,13 @@ class MumbleAuthenticator(Murmur.ServerUpdatingAuthenticator):
         if username == "SuperUser":
             return (-2, None, None)
 
+        # The ATAK Vx plugin sends the Mumble username as "callsign---uid".
+        # Strip the UID suffix so lookup matches the OTS account (named after the callsign).
+        if "---" in username:
+            callsign = username.split("---")[0].strip()
+            if callsign:
+                username = callsign
+
         self.logger.info("Mumble auth request for {}".format(username))
 
         with self.app.app_context():

--- a/tests/test_mumble_authenticator.py
+++ b/tests/test_mumble_authenticator.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("Ice")
+
+from opentakserver.mumble.mumble_authenticator import MumbleAuthenticator
+
+
+def make_authenticator():
+    auth = MumbleAuthenticator.__new__(MumbleAuthenticator)  # skip __init__/Ice setup
+    auth.app = MagicMock()
+    auth.logger = MagicMock()
+    datastore = auth.app.security.datastore
+    datastore.find_user.return_value = None  # -> returns -1 before touching password logic
+    return auth, datastore
+
+
+@pytest.mark.parametrize(
+    "raw_username,expected_lookup",
+    [
+        ("ANVIL---47c4c853-4e52-4b97-9a0b-08a0f961b0fa", "ANVIL"),
+        ("plainuser", "plainuser"),
+    ],
+)
+def test_username_lookup_strips_atak_vx_uid_suffix(raw_username, expected_lookup):
+    auth, datastore = make_authenticator()
+
+    auth.authenticate(raw_username, "password", None, None, None)
+
+    datastore.find_user.assert_called_once_with(username=expected_lookup)


### PR DESCRIPTION
## Summary
- The ATAK Vx plugin connects to Mumble using a username of the form `callsign---uid` (e.g. `ANVIL---47c4c853-4e52-4b97-9a0b-08a0f961b0fa`).
- `MumbleAuthenticator.authenticate()` looked up that full string in the OTS user database, which never matches an account (registered under just the callsign, e.g. `ANVIL`). Every Vx connection was rejected by Mumble with "Wrong certificate or password for existing user".
- This strips the `---uid` suffix before the `find_user` lookup, so authentication succeeds when the OTS username matches the ATAK callsign.

Tested against OTS 1.7.12, ATAK 5.6.0.12, and the Vx plugin.

## Test plan
- [x] Added `tests/test_mumble_authenticator.py` covering the `callsign---uid` and plain-username cases (guarded with `pytest.importorskip("Ice")` since Ice is a platform-specific dependency)
- [x] Manually reproduced the failure and confirmed the fix on a live OTS/Mumble deployment with an ATAK Vx client