### PR TITLE
fix: include OTS_SSL_STREAMING_PORT in ATAK QR enrollment URL

### DIFF
--- a/opentakserver/blueprints/ots_api/token_api.py
+++ b/opentakserver/blueprints/ots_api/token_api.py
@@ -92,7 +92,7 @@ def new_atak_qr_string():
     :param nbf: Not Before, the token will not be valid until this date in unix epoch seconds.
     :param max: The maximum number of uses for this token.
 
-    :return: String in the format of tak://com.atakmap.app/enroll?host=server_address.com&username=your_username&token=jwt_token
+    :return: String in the format of tak://com.atakmap.app/enroll?host=server_address.com:PORT&username=your_username&token=jwt_token
     """
     try:
         username = request.json.get("username") or current_user.username
@@ -148,7 +148,9 @@ def new_atak_qr_string():
             response["success"] = True
             response["disabled"] = token.disabled
             response["qr_string"] = (
-                f"tak://com.atakmap.app/enroll?host={urlparse(request.url_root).hostname}&username={username}&token={token.generate_token()}"
+                f"tak://com.atakmap.app/enroll?host={urlparse(request.url_root).hostname}"
+                f":{app.config.get('OTS_SSL_STREAMING_PORT')}"
+                f"&username={username}&token={token.generate_token()}"
             )
             return jsonify(response)
 
@@ -164,7 +166,7 @@ def get_atak_qr_strings():
     """
     Returns an existing ATAK QR string
 
-    :return: String in the format of tak://com.atakmap.app/enroll?host=server_address.com&username=your_username&token=jwt_token
+    :return: String in the format of tak://com.atakmap.app/enroll?host=server_address.com:PORT&username=your_username&token=jwt_token
     """
 
     query = db.session.query(Token)
@@ -183,7 +185,9 @@ def get_atak_qr_strings():
         response["disabled"] = token[0].disabled
         response["total_uses"] = token[0].total_uses
         response["qr_string"] = (
-            f"tak://com.atakmap.app/enroll?host={urlparse(request.url_root).hostname}&username={token[0].username}&token={token[0].generate_token()}"
+            f"tak://com.atakmap.app/enroll?host={urlparse(request.url_root).hostname}"
+            f":{app.config.get('OTS_SSL_STREAMING_PORT')}"
+            f"&username={token[0].username}&token={token[0].generate_token()}"
         )
         return jsonify(response)
     else:


### PR DESCRIPTION
## Problem

The QR string generated by both `POST` and `GET /api/atak_qr_string` uses only the bare hostname — no port:

```
tak://com.atakmap.app/enroll?host=example.com&username=...&token=...
```

When ATAK receives a `host=` value with no port, it falls back to its **compiled-in default SSL CoT port: 8089**.

This means:

| Scenario | QR works? |
|---|---|
| Default install, `OTS_SSL_STREAMING_PORT=8089`, accessed directly | ✅ works by accident |
| Any deployment where `OTS_SSL_STREAMING_PORT` ≠ 8089 (e.g. Docker port remapping) | ❌ broken — ATAK tries port 8089 |

The Docker setup (`OpenTAKServer-Docker`) exposes the SSL CoT handler on whatever port the operator configures via `OTS_SSL_STREAMING_PORT`, so this affects every Docker user who customises the port.

## Fix

Append `OTS_SSL_STREAMING_PORT` directly to the hostname in both handlers:

```python
# Before
f"tak://com.atakmap.app/enroll?host={urlparse(request.url_root).hostname}&username={username}&token={token.generate_token()}"

# After
f"tak://com.atakmap.app/enroll?host={urlparse(request.url_root).hostname}"
f":{app.config.get('OTS_SSL_STREAMING_PORT')}"
f"&username={username}&token={token.generate_token()}"
```

The same change is applied to the `GET` handler at line 186. Both docstrings are also updated to document the port in the return format.

## Files changed

- `opentakserver/blueprints/ots_api/token_api.py` — 4 lines changed (2 `qr_string` assignments + 2 docstrings)

## Testing

1. Set `OTS_SSL_STREAMING_PORT` to any non-8089 value (e.g. `12701`) in your config.
2. Generate a QR code from the web UI (Certificates → Generate QR).
3. Verify the QR encodes `host=yourserver.com:12701` rather than `host=yourserver.com`.
4. Scan the QR code with ATAK — enrollment should complete and ATAK should connect on the correct port.