### PR TITLE
Keep an EUD's team colour current for the whole connection

### DIFF
--- a/opentakserver/cot_parser/cot_parser.py
+++ b/opentakserver/cot_parser/cot_parser.py
@@ -74,6 +74,11 @@ class CoTController:
 
         self.exchanges = []
 
+        # Last team colour seen per EUD uid, so update_team_from_cot only
+        # touches the database when it actually changed rather than on every
+        # position update.
+        self.last_team = {}
+
         self.rabbit_connection: pika.BlockingConnection = None
         self.rabbit_channel = None
 
@@ -256,6 +261,8 @@ class CoTController:
                 # to the UI's map
                 if event.find("takv") or event.find("__video"):
                     self.socketio.emit("point", p.to_json(), namespace="/socket.io")
+
+                self.update_team_from_cot(event, uid)
 
                 if self.context.app.config.get("OTS_ENABLE_MESHTASTIC"):
                     try:
@@ -878,6 +885,75 @@ class CoTController:
 
                     rb_line.point = start_point
                     self.socketio.emit("rb_line", rb_line.to_json(), namespace="/socket.io")
+
+    def update_team_from_cot(self, event, uid):
+        """Keep an EUD's team colour current for the whole connection.
+
+        EudHandler.parse_device_info is the only other writer of eud.team_id,
+        and it runs behind `if event and not self.uid` - once, on the first CoT
+        of a TCP connection. An operator who changes team colour mid-connection
+        therefore keeps their old colour in the database and on the web UI map
+        until they reconnect, however many SA updates arrive in between.
+
+        That matters because team colour is how some deployments carry live
+        state (for example marking a player out of the game), and the map is
+        the thing people watch. Peers are unaffected either way - EudHandler
+        relays the original CoT verbatim, so other clients parse __group
+        themselves and always see the current colour.
+
+        Called per position update, so it compares against self.last_team and
+        only touches the database when the colour actually changed. On a change
+        it also emits the 'eud' socketio event, which is what makes an already
+        open map recolour without a reload.
+        """
+        __group = event.find("__group")
+        if not __group or "name" not in __group.attrs:
+            return
+
+        team_name = bleach.clean(__group.attrs["name"])
+        if not team_name or self.last_team.get(uid) == team_name:
+            return
+
+        try:
+            team = self.db.session.execute(
+                select(Team).filter(Team.name == team_name)
+            ).first()
+            if team:
+                team = team[0]
+            else:
+                team = Team()
+                team.name = team_name
+                try:
+                    self.db.session.add(team)
+                    self.db.session.commit()
+                except sqlalchemy.exc.IntegrityError:
+                    # Another cot_parser process created it first.
+                    self.db.session.rollback()
+                    team = self.db.session.execute(
+                        select(Team).filter(Team.name == team_name)
+                    ).first()[0]
+
+            eud = self.db.session.execute(select(EUD).filter_by(uid=uid)).first()
+            if not eud:
+                return
+            eud = eud[0]
+
+            if eud.team_id != team.id:
+                eud.team_id = team.id
+                if "role" in __group.attrs:
+                    eud.team_role = bleach.clean(__group.attrs["role"])
+                self.db.session.add(eud)
+                self.db.session.commit()
+                self.logger.debug(f"{uid} team is now {team_name}")
+                self.socketio.emit("eud", eud.to_json(), namespace="/socket.io")
+
+            # Only cache after a successful update, so a failure retries on the
+            # next position update instead of being swallowed until reconnect.
+            self.last_team[uid] = team_name
+        except BaseException as e:
+            self.db.session.rollback()
+            self.logger.error(f"Failed to update team for {uid}: {e}")
+            self.logger.debug(traceback.format_exc())
 
     def parse_stats(self, event, uid):
         stats = event.find("stats")


### PR DESCRIPTION
### Problem

`eud.team_id` is only written in `EudHandler.parse_device_info`, which `handle_cot` calls behind:

```python
if event and not self.uid:
    self.parse_device_info(event)
```

So it runs once, on the first CoT of a TCP connection. If an operator changes their team colour while connected, the database keeps the old value until they reconnect, however many SA updates arrive in between.

The web UI map reads `team_color` off that row, so the marker keeps the old colour, and refreshing the browser doesn't help — the stale value is in the database, not the page.

### How I ran into it

I use team colour to carry live state during airsoft games: a player who's out switches to a reserved colour so everyone can see they're out. The web map is what the game master watches, and it kept showing the pre-change colour for the rest of the session.

Measured on 1.7.11 — the device was broadcasting `<__group name="Cyan" role="Team Member"/>` while `euds.team_id` still pointed at the colour it had when it connected, the last connect being 9 seconds before the change.

Other clients were never affected. `EudHandler.on_message` relays the original CoT verbatim, so ATAK/iTAK parse `__group` themselves and always saw the right colour. It's only the server's own view that goes stale.

### Fix

`cot_parser` already sees every position update and owns both the EUD rows and the socketio emits, so the refresh goes there.

- Compares against a per-uid cache and only touches the database when the colour actually changed, so the common case is one dict lookup per position update.
- Emits the `eud` event on change, which is what makes an already open map recolour without a reload.
- Team creation mirrors `parse_device_info`, including the `IntegrityError` fallback for when another `cot_parser` process creates the same team first.
- The cache is only written after a successful update, so a failure retries on the next position update instead of being swallowed until the EUD reconnects.

### Testing

Running this on my own server against ATAK-CIV 5.7.0.10.

- Changed team colour mid-session with no reconnect: `euds.team_id` follows within one position update (measured about a second), and an already open map recolours without a reload. Before the change the same test left the row stale indefinitely.
- Verified in both directions, including back to the original colour.
- No extra database writes while the colour is unchanged — the cache short-circuits before any query.

### Note

Callsign, ATAK version and `team_role` are set in the same connect-only block and go stale the same way. I left those alone to keep this focused, but happy to extend it if you'd like the same treatment.