### PR TITLE
fix(cot_parser): stream position updates for EUDs

### DIFF
--- a/opentakserver/cot_parser/cot_parser.py
+++ b/opentakserver/cot_parser/cot_parser.py
@@ -252,9 +252,10 @@ class CoTController:
                 ).first()[0]
 
                 # This CoT is a position update for an EUD. Send it to socketio clients so it can be seen on the UI map
-                # OpenTAK ICU position updates don't include the <takv> tag, but we still want to send the updated position
-                # to the UI's map
-                if event.find("takv") or event.find("__video"):
+                # Not every EUD sends <takv>: OpenTAK ICU omits it, and so do non-ATAK clients that connect directly
+                # to the server (e.g. Somewear's direct server connection) and CoT bridges/gateways. Those positions
+                # reach ATAK/iTAK fine but never reached the UI's map. <contact> is what every EUD position carries.
+                if event.find("takv") or event.find("__video") or event.find("contact") is not None:
                     self.socketio.emit("point", p.to_json(), namespace="/socket.io")
 
                 if self.context.app.config.get("OTS_ENABLE_MESHTASTIC"):


### PR DESCRIPTION
fix(cot_parser): stream position updates for EUDs without <takv> to the UI map

The socketio emit that feeds the web UI's map was gated on the CoT carrying <takv> or <__video>. EUDs that connect directly to the server without being ATAK - Somewear's direct server connection, CoT bridges/gateways, and (as the existing comment notes) OpenTAK ICU - send <contact>, <__group> and <track> but no <takv>, so their positions were parsed and stored correctly, reached ATAK/iTAK clients normally, and then never appeared on the web map.

Broaden the condition to also emit when <contact> is present, which every EUD position update carries.

Fixes #339