### PR TITLE
fix(logging): prevent duplicate OpenTAKServer log lines

### DIFF
--- a/opentakserver/extensions.py
+++ b/opentakserver/extensions.py
@@ -10,6 +10,7 @@ from flask_sqlalchemy import SQLAlchemy
 from opentakserver.models.Base import Base
 
 logger = colorlog.getLogger("OpenTAKServer")
+logger.propagate = False
 
 mail = Mail()
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,21 @@
+import io
+import logging
+
+from opentakserver.extensions import logger
+
+
+def test_opentakserver_logger_does_not_propagate_to_root(monkeypatch):
+    root_logger = logging.getLogger()
+    named_output = io.StringIO()
+    root_output = io.StringIO()
+
+    monkeypatch.setattr(logger, "handlers", [logging.StreamHandler(named_output)])
+    monkeypatch.setattr(root_logger, "handlers", [logging.StreamHandler(root_output)])
+    monkeypatch.setattr(logger, "disabled", False)
+    monkeypatch.setattr(logger, "level", logging.DEBUG)
+
+    logger.debug("logging-regression-sentinel")
+
+    assert logger.propagate is False
+    assert named_output.getvalue() == "logging-regression-sentinel\n"
+    assert root_output.getvalue() == ""


### PR DESCRIPTION
## Summary

- stop the shared `OpenTAKServer` logger from propagating records to the root logger
- add a behavioral regression test proving the named handler receives one record while the root handler receives none

## Root cause

OpenTAKServer configures handlers directly on its named logger, but the logger retained Python's default `propagate=True`. When a dependency or runtime also configured the root logger, the same record was emitted by both handler chains.

The named logger's existing file and TTY handlers are unchanged. In non-TTY environments, this intentionally removes the accidental bare root/stderr copy while preserving the configured file output.

## Validation

- regression test confirmed failing before the source change and passing after it
- `.venv/bin/python -m pytest tests/test_logging.py -q` (`1 passed`)
- `.venv/bin/python -m pytest -q` (`1 passed, 1 skipped`)
- `.venv/bin/python -m black --check --line-ranges 13-13 opentakserver/extensions.py`
- `.venv/bin/python -m black --check tests/test_logging.py`
- `.venv/bin/python -m isort --check-only opentakserver/extensions.py tests/test_logging.py`
- `.venv/bin/python -m flake8 opentakserver/extensions.py tests/test_logging.py`
- `git diff --check origin/master...HEAD`

Thanks to @TX-RX for the clear report and suggested direction.

Fixes #304

Generated-by: OpenAI Codex (GPT-5)
