### PR TITLE
fix(scheduler): purge mission invitations before missions

### DIFF
--- a/opentakserver/blueprints/scheduled_jobs.py
+++ b/opentakserver/blueprints/scheduled_jobs.py
@@ -186,6 +186,7 @@ def purge_data():
     MissionContentMission.query.delete()
     MissionUID.query.delete()
     MissionChange.query.delete()
+    MissionInvitation.query.delete()
     Mission.query.delete()
     EUD.query.delete()
     Team.query.delete()

--- a/tests/test_scheduled_jobs.py
+++ b/tests/test_scheduled_jobs.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+from opentakserver.blueprints import scheduled_jobs
+
+
+def test_purge_data_deletes_mission_invitations_before_missions(monkeypatch):
+    deleted = []
+    state = {"mission_invitations": 1}
+
+    class Query:
+        def __init__(self, model_name):
+            self.model_name = model_name
+
+        def delete(self):
+            deleted.append(self.model_name)
+            if self.model_name == "MissionInvitation":
+                state["mission_invitations"] = 0
+            if self.model_name == "Mission" and state["mission_invitations"]:
+                raise AssertionError("mission_invitations still references missions")
+
+    model_names = (
+        "ZMIST",
+        "VideoStream",
+        "Alert",
+        "CasEvac",
+        "Certificate",
+        "ChatroomsUids",
+        "DataPackage",
+        "Marker",
+        "GeoChat",
+        "Point",
+        "RBLine",
+        "Chatroom",
+        "CoT",
+        "MissionRole",
+        "MissionContentMission",
+        "MissionUID",
+        "MissionChange",
+        "MissionInvitation",
+        "Mission",
+        "EUD",
+        "Team",
+    )
+    for model_name in model_names:
+        monkeypatch.setattr(
+            scheduled_jobs,
+            model_name,
+            SimpleNamespace(query=Query(model_name)),
+        )
+
+    monkeypatch.setattr(scheduled_jobs, "delete_video_recordings", lambda: None)
+    monkeypatch.setattr(
+        scheduled_jobs,
+        "db",
+        SimpleNamespace(session=SimpleNamespace(commit=lambda: None)),
+    )
+    monkeypatch.setattr(scheduled_jobs, "logger", SimpleNamespace(info=lambda _message: None))
+
+    scheduled_jobs.purge_data()
+
+    assert deleted.index("MissionInvitation") < deleted.index("Mission")


### PR DESCRIPTION
Fixes #292.

`purge_data()` uses bulk deletes in an explicit foreign-key order. It deleted missions without first deleting `MissionInvitation` rows, so an active mission with an invitation caused PostgreSQL to reject the purge with a foreign-key violation.

Delete mission invitations immediately before missions and add a focused regression that enforces the dependency order.

## Validation

- exact `master` baseline: the regression fails before `Mission` deletion because the invitation still references it
- `.venv/bin/python -m pytest -o addopts='' -q tests/test_scheduled_jobs.py` (`1 passed`)
- full available repository suite (`1 passed, 1 skipped`)
- Black, isort, Flake8, `compileall`, and `git diff --check` passed
- independent SQLite foreign-key oracle: baseline raises `IntegrityError`; patched purge removes both rows and remains idempotent

## AI assistance disclosure

OpenAI Codex assisted with issue triage, implementation, tests, and independent review. The account owner authorized publication of this contribution.
